### PR TITLE
Add minimal Vercel-ready npm web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# vercel_demo
+# Vercel Demo Web App
+
+This repository contains a tiny example of an npm-powered web application that can be deployed to [Vercel](https://vercel.com). It exposes a static landing page backed by a single serverless API route.
+
+## Project structure
+
+```
+.
+├── api/hello.js      # Serverless function returning JSON
+├── app.js            # Front-end script fetching data from the API route
+├── dev-server.js     # Lightweight local development server (no external deps)
+├── index.html        # Static landing page
+├── package.json      # npm metadata and scripts
+├── styles.css        # Styling for the landing page
+└── vercel.json       # Minimal Vercel configuration
+```
+
+## Getting started locally
+
+This project does not rely on any third-party npm packages, so there is nothing to install. To experiment locally, make sure you have Node.js 18 or newer and run:
+
+```bash
+npm install          # Optional: creates a lockfile, no packages are downloaded
+npm run dev          # Starts the lightweight dev server on http://localhost:3000
+```
+
+Open <http://localhost:3000> in your browser. The page will call the `/api/hello` endpoint which, in this local mode, is handled directly by the dev server.
+
+## Deploying to Vercel
+
+1. Push this repository to your own GitHub (or GitLab/Bitbucket) account.
+2. Create a new project in the Vercel dashboard and import the repository.
+3. Vercel detects the `index.html` file and serves it as a static asset. The `api/hello.js` file becomes a serverless function available at `/api/hello`.
+4. Once the deployment completes, visit the generated URL to see the page and JSON API in action.
+
+> **Tip:** The optional `vercel.json` file rewrites the root path (`/`) to `index.html`, ensuring the static file is served even when the project also contains API routes.
+
+## Customization ideas
+
+- Update the `api/hello.js` function to read data from an external service.
+- Replace the static HTML page with a client-side framework of your choice.
+- Extend `dev-server.js` to watch files and reload automatically during development.
+
+Have fun experimenting with Vercel deployments! ✨

--- a/api/hello.js
+++ b/api/hello.js
@@ -1,0 +1,9 @@
+module.exports = (req, res) => {
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.status(200).send(
+    JSON.stringify({
+      message: 'Hello from Vercel!',
+      timestamp: new Date().toISOString()
+    })
+  );
+};

--- a/app.js
+++ b/app.js
@@ -1,0 +1,24 @@
+async function fetchGreeting() {
+  const messageEl = document.getElementById('api-message');
+  const timestampEl = document.getElementById('api-timestamp');
+
+  try {
+    const response = await fetch('/api/hello');
+
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+
+    const data = await response.json();
+    messageEl.textContent = data.message;
+    timestampEl.textContent = `Received at ${new Date(data.timestamp).toLocaleString()}`;
+  } catch (error) {
+    console.error('Unable to load the API response:', error);
+    messageEl.textContent = 'Something went wrong while reaching the API.';
+    timestampEl.textContent = '';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  fetchGreeting();
+});

--- a/dev-server.js
+++ b/dev-server.js
@@ -1,0 +1,65 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const port = process.env.PORT || 3000;
+
+const mimeTypes = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.ico': 'image/x-icon'
+};
+
+function sendJson(res, data) {
+  const body = JSON.stringify(data);
+  res.writeHead(200, {
+    'Content-Type': mimeTypes['.json'],
+    'Content-Length': Buffer.byteLength(body)
+  });
+  res.end(body);
+}
+
+function serveStaticFile(res, filePath) {
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      if (err.code === 'ENOENT') {
+        res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('Not found');
+      } else {
+        res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('Internal server error');
+      }
+      return;
+    }
+
+    const ext = path.extname(filePath).toLowerCase();
+    const contentType = mimeTypes[ext] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(content);
+  });
+}
+
+const server = http.createServer((req, res) => {
+  const { url, method } = req;
+
+  if (method === 'GET' && url === '/api/hello') {
+    sendJson(res, {
+      message: 'Hello from the local development server!',
+      timestamp: new Date().toISOString()
+    });
+    return;
+  }
+
+  // sanitize path to prevent directory traversal
+  const safePath = path.normalize(decodeURIComponent(url)).replace(/^\.\//, '').replace(/^\/+/, '');
+  const requestedPath = safePath === '' ? 'index.html' : safePath;
+  const filePath = path.join(__dirname, requestedPath);
+
+  serveStaticFile(res, filePath);
+});
+
+server.listen(port, () => {
+  console.log(`Development server running at http://localhost:${port}`);
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Vercel NPM Web App Demo</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Welcome to the Vercel Demo</h1>
+      <p>This is a minimal static page served by an npm project.</p>
+      <section class="card" id="api-card">
+        <h2>Serverless API response</h2>
+        <p id="api-message">Loading…</p>
+        <p class="timestamp" id="api-timestamp"></p>
+      </section>
+    </main>
+    <footer>
+      <p>Deployed with <a href="https://vercel.com" target="_blank" rel="noreferrer">Vercel</a>.</p>
+    </footer>
+    <script src="app.js" defer></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "vercel-demo",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vercel-demo",
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "vercel-demo",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Very basic example of an npm web app that can be deployed to Vercel.",
+  "scripts": {
+    "dev": "node dev-server.js",
+    "start": "node dev-server.js"
+  },
+  "keywords": [
+    "vercel",
+    "demo",
+    "static-site"
+  ],
+  "author": "",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,82 @@
+:root {
+  color-scheme: light dark;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: #0f172a;
+  color: #e2e8f0;
+  line-height: 1.6;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+main.container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  padding: 2rem 1rem 3rem;
+  text-align: center;
+}
+
+h1 {
+  font-size: clamp(2.5rem, 6vw, 3.5rem);
+  margin: 0;
+}
+
+p {
+  margin: 0;
+  max-width: 45ch;
+}
+
+.card {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 1rem;
+  padding: 1.5rem 2rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(16px);
+}
+
+.card h2 {
+  margin-top: 0;
+  font-size: clamp(1.5rem, 4vw, 2rem);
+}
+
+.timestamp {
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+  color: #94a3b8;
+}
+
+a {
+  color: #38bdf8;
+}
+
+a:hover,
+a:focus {
+  text-decoration: none;
+}
+
+footer {
+  text-align: center;
+  padding: 1.5rem 0 2rem;
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+@media (max-width: 600px) {
+  main.container {
+    padding: 1.5rem 1rem 2rem;
+  }
+
+  .card {
+    width: 100%;
+    padding-inline: 1.5rem;
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a static landing page, styles, and client script that fetches the API response
- provide a lightweight Node-based dev server and serverless function example
- document local usage and Vercel deployment steps with a minimal config

## Testing
- node dev-server.js (manual verification with curl)
- curl http://localhost:3000/api/hello


------
https://chatgpt.com/codex/tasks/task_e_68d13755537c832081a7fcbda0a23bca