### PR TITLE
Enhance demo page with interactive sections

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,45 @@
+let latestGreeting = null;
+let isFetchingGreeting = false;
+
+function updatePersonalizedPreview() {
+  const input = document.getElementById('name-input');
+  const output = document.getElementById('personalized-output');
+
+  if (!input || !output) {
+    return;
+  }
+
+  const value = input.value.trim();
+  if (value.length === 0) {
+    output.textContent = 'Enter a name to craft a friendly greeting.';
+    return;
+  }
+
+  const baseMessage = latestGreeting?.message || 'Hello from the Vercel demo!';
+  output.textContent = `${baseMessage} Let’s build something great, ${value}!`;
+}
+
 async function fetchGreeting() {
+  if (isFetchingGreeting) {
+    return;
+  }
+
   const messageEl = document.getElementById('api-message');
   const timestampEl = document.getElementById('api-timestamp');
+  const refreshButton = document.getElementById('refresh-btn');
+
+  if (!messageEl || !timestampEl) {
+    return;
+  }
+
+  isFetchingGreeting = true;
+  messageEl.textContent = 'Requesting the latest message…';
+  timestampEl.textContent = '';
+
+  if (refreshButton) {
+    refreshButton.disabled = true;
+    refreshButton.textContent = 'Refreshing…';
+  }
 
   try {
     const response = await fetch('/api/hello');
@@ -10,15 +49,180 @@ async function fetchGreeting() {
     }
 
     const data = await response.json();
+    latestGreeting = data;
     messageEl.textContent = data.message;
     timestampEl.textContent = `Received at ${new Date(data.timestamp).toLocaleString()}`;
   } catch (error) {
     console.error('Unable to load the API response:', error);
+    latestGreeting = null;
     messageEl.textContent = 'Something went wrong while reaching the API.';
-    timestampEl.textContent = '';
+  } finally {
+    isFetchingGreeting = false;
+    if (refreshButton) {
+      refreshButton.disabled = false;
+      refreshButton.textContent = 'Refresh';
+    }
+    updatePersonalizedPreview();
   }
 }
 
+function setupPersonalizer() {
+  const form = document.getElementById('personalize-form');
+  const input = document.getElementById('name-input');
+
+  if (!form || !input) {
+    return;
+  }
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    updatePersonalizedPreview();
+    input.focus();
+  });
+
+  input.addEventListener('input', () => {
+    updatePersonalizedPreview();
+  });
+
+  updatePersonalizedPreview();
+}
+
+function loadChecklistState(key) {
+  try {
+    const stored = localStorage.getItem(key);
+    if (!stored) {
+      return {};
+    }
+    const parsed = JSON.parse(stored);
+    if (typeof parsed === 'object' && parsed !== null) {
+      return parsed;
+    }
+  } catch (error) {
+    console.warn('Unable to read checklist progress from localStorage:', error);
+  }
+  return {};
+}
+
+function saveChecklistState(key, value) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.warn('Unable to save checklist progress to localStorage:', error);
+  }
+}
+
+function setupChecklist() {
+  const checklistEl = document.getElementById('checklist');
+  const progressBar = document.getElementById('progress-bar');
+  const progressLabel = document.getElementById('progress-label');
+
+  if (!checklistEl || !progressBar || !progressLabel) {
+    return;
+  }
+
+  const STORAGE_KEY = 'vercel-demo-checklist';
+  const tasks = [
+    { id: 'repo', label: 'Connect your Git repository to Vercel' },
+    { id: 'env', label: 'Configure required environment variables' },
+    { id: 'preview', label: 'Test a preview deployment and share the link' },
+    { id: 'monitoring', label: 'Set up monitoring or analytics for launch day' },
+    { id: 'teammates', label: 'Invite teammates to collaborate on the project' }
+  ];
+
+  const savedState = loadChecklistState(STORAGE_KEY);
+
+  function updateProgress() {
+    const checkboxes = checklistEl.querySelectorAll('input[type="checkbox"]');
+    const completed = Array.from(checkboxes).filter((checkbox) => checkbox.checked).length;
+    const percent = Math.round((completed / tasks.length) * 100);
+
+    progressBar.style.width = `${percent}%`;
+    progressBar.setAttribute('aria-valuenow', String(percent));
+    progressBar.setAttribute(
+      'aria-valuetext',
+      `${completed} of ${tasks.length} steps complete`
+    );
+    progressLabel.textContent = `You're ${completed} of ${tasks.length} steps done (${percent}%).`;
+  }
+
+  tasks.forEach((task) => {
+    const listItem = document.createElement('li');
+    const label = document.createElement('label');
+    label.className = 'checklist-item';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.id = `checklist-${task.id}`;
+    checkbox.checked = Boolean(savedState[task.id]);
+    checkbox.dataset.taskId = task.id;
+
+    const text = document.createElement('span');
+    text.textContent = task.label;
+
+    checkbox.addEventListener('change', () => {
+      savedState[task.id] = checkbox.checked;
+      saveChecklistState(STORAGE_KEY, savedState);
+      updateProgress();
+    });
+
+    label.append(checkbox, text);
+    listItem.append(label);
+    checklistEl.append(listItem);
+  });
+
+  progressBar.setAttribute('role', 'progressbar');
+  progressBar.setAttribute('aria-valuemin', '0');
+  progressBar.setAttribute('aria-valuemax', '100');
+  progressBar.setAttribute('aria-label', 'Launch checklist progress');
+
+  updateProgress();
+}
+
+function setupTips() {
+  const tipMessage = document.getElementById('tip-message');
+  const tipButton = document.getElementById('tip-button');
+
+  if (!tipMessage || !tipButton) {
+    return;
+  }
+
+  const tips = [
+    'Preview deployments are perfect for gathering quick feedback from stakeholders.',
+    'Use environment variables to keep secrets out of your repository.',
+    'Need scheduled jobs? Pair serverless functions with background cron triggers.',
+    'Share the preview URL with teammates so they can comment before you ship.',
+    'Monitor function logs in the Vercel dashboard to understand real traffic patterns.'
+  ];
+
+  let previousIndex = -1;
+
+  function showRandomTip() {
+    let nextIndex = Math.floor(Math.random() * tips.length);
+    if (tips.length > 1 && nextIndex === previousIndex) {
+      nextIndex = (nextIndex + 1) % tips.length;
+    }
+    previousIndex = nextIndex;
+    tipMessage.textContent = tips[nextIndex];
+  }
+
+  tipButton.addEventListener('click', () => {
+    showRandomTip();
+    tipButton.blur();
+  });
+
+  showRandomTip();
+}
+
 document.addEventListener('DOMContentLoaded', () => {
+  const refreshButton = document.getElementById('refresh-btn');
+  if (refreshButton) {
+    refreshButton.addEventListener('click', () => {
+      fetchGreeting();
+    });
+  }
+
+  setupPersonalizer();
+  setupChecklist();
+  setupTips();
   fetchGreeting();
 });

--- a/index.html
+++ b/index.html
@@ -8,13 +8,64 @@
   </head>
   <body>
     <main class="container">
-      <h1>Welcome to the Vercel Demo</h1>
-      <p>This is a minimal static page served by an npm project.</p>
+      <header class="hero">
+        <h1>Welcome to the Vercel Demo</h1>
+        <p>
+          Explore how a lightweight static site can talk to serverless functions and
+          guide you toward launch-ready projects.
+        </p>
+      </header>
+
       <section class="card" id="api-card">
-        <h2>Serverless API response</h2>
-        <p id="api-message">Loading…</p>
+        <div class="card-header">
+          <h2>Serverless API response</h2>
+          <button class="button subtle" id="refresh-btn" type="button">Refresh</button>
+        </div>
+        <p class="lead" id="api-message" role="status">Loading…</p>
         <p class="timestamp" id="api-timestamp"></p>
       </section>
+
+      <section class="card" id="personalize-card">
+        <h2>Personalize the greeting</h2>
+        <p>
+          Use the latest API message as a starting point and tailor it to your team or
+          project.
+        </p>
+        <form class="form" id="personalize-form">
+          <label class="form-field" for="name-input">Your name or team</label>
+          <div class="form-controls">
+            <input
+              id="name-input"
+              name="name"
+              type="text"
+              placeholder="e.g. Static Site Ninjas"
+              autocomplete="off"
+            />
+            <button class="button primary" type="submit">Preview message</button>
+          </div>
+        </form>
+        <p class="preview" id="personalized-output">
+          Enter a name to craft a friendly greeting.
+        </p>
+      </section>
+
+      <div class="grid">
+        <section class="card" id="checklist-card">
+          <h2>Launch checklist</h2>
+          <p>Tick the boxes as you get your deployment ready.</p>
+          <ul class="checklist" id="checklist"></ul>
+          <div class="progress">
+            <div class="progress-bar" id="progress-bar"></div>
+          </div>
+          <p class="progress-label" id="progress-label" role="status"></p>
+        </section>
+
+        <section class="card" id="tip-card">
+          <h2>Quick tip</h2>
+          <p id="tip-message">Loading tip…</p>
+          <button class="button subtle" id="tip-button" type="button">Show another tip</button>
+        </section>
+      </div>
     </main>
     <footer>
       <p>Deployed with <a href="https://vercel.com" target="_blank" rel="noreferrer">Vercel</a>.</p>

--- a/styles.css
+++ b/styles.css
@@ -17,11 +17,23 @@ main.container {
   flex: 1;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 1.5rem;
-  padding: 2rem 1rem 3rem;
+  gap: 1.75rem;
+  padding: 3.5rem 1.25rem 4rem;
+  max-width: min(960px, 92vw);
+  margin: 0 auto;
+  text-align: left;
+}
+
+.hero {
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.hero p {
+  max-width: 54ch;
 }
 
 h1 {
@@ -38,14 +50,182 @@ p {
   background: rgba(15, 23, 42, 0.65);
   border: 1px solid rgba(148, 163, 184, 0.3);
   border-radius: 1rem;
-  padding: 1.5rem 2rem;
+  padding: 1.75rem 2.25rem;
   box-shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
   backdrop-filter: blur(16px);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .card h2 {
   margin-top: 0;
   font-size: clamp(1.5rem, 4vw, 2rem);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.lead {
+  font-size: clamp(1.05rem, 2.5vw, 1.2rem);
+}
+
+.button {
+  background: rgba(59, 130, 246, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 999px;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0.55rem 1.25rem;
+  transition: transform 150ms ease, background 150ms ease, border-color 150ms ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.button:hover,
+.button:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(148, 163, 184, 0.75);
+  background: rgba(59, 130, 246, 0.22);
+}
+
+.button:active {
+  transform: translateY(0);
+}
+
+.button.primary {
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.2), rgba(129, 140, 248, 0.35));
+  border-color: rgba(125, 211, 252, 0.4);
+  color: #f8fafc;
+}
+
+.button.subtle {
+  font-weight: 500;
+}
+
+.button:disabled {
+  cursor: progress;
+  opacity: 0.65;
+  transform: none;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.form-field {
+  font-weight: 600;
+}
+
+.form-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+input[type='text'] {
+  flex: 1 1 220px;
+  padding: 0.65rem 0.9rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(15, 23, 42, 0.35);
+  color: inherit;
+  font-size: 1rem;
+  outline: none;
+  transition: border-color 150ms ease, box-shadow 150ms ease, background 150ms ease;
+}
+
+input[type='text']::placeholder {
+  color: rgba(148, 163, 184, 0.7);
+}
+
+input[type='text']:focus {
+  border-color: rgba(96, 165, 250, 0.7);
+  box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.15);
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.preview {
+  background: rgba(148, 163, 184, 0.08);
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  font-style: italic;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.checklist {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.checklist-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  font-weight: 500;
+}
+
+.checklist-item span {
+  flex: 1;
+}
+
+.checklist-item input[type='checkbox'] {
+  width: 1.15rem;
+  height: 1.15rem;
+  margin: 0.1rem 0 0;
+  accent-color: #38bdf8;
+}
+
+.progress {
+  height: 0.65rem;
+  background: rgba(148, 163, 184, 0.25);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-bar {
+  height: 100%;
+  width: 0;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.6), rgba(165, 180, 252, 0.8));
+  border-radius: inherit;
+  transition: width 200ms ease-in-out;
+}
+
+.progress-label {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+#tip-card {
+  justify-content: space-between;
+}
+
+#tip-message {
+  min-height: 3.5rem;
+}
+
+#tip-button {
+  align-self: flex-start;
 }
 
 .timestamp {
@@ -72,11 +252,20 @@ footer {
 
 @media (max-width: 600px) {
   main.container {
-    padding: 1.5rem 1rem 2rem;
+    padding: 2rem 1.1rem 3rem;
   }
 
   .card {
     width: 100%;
     padding-inline: 1.5rem;
+  }
+
+  .card-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .button {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- expand the landing content with a richer hero, an API refresh control, and new interactive sections
- add client-side logic for greeting personalization, a persistent launch checklist, and rotating deployment tips
- refresh styling to support the new layout, buttons, form controls, and progress visualization

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68d13a08b1d48320ac8295371aff31a1