### PR TITLE
Switch dashboard panels to tabbed workspace

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,49 +76,94 @@
         </div>
       </header>
 
-      <section class="app-grid" aria-label="Training controls">
-        <section class="panel exercise-panel" id="exercise-card">
-          <div class="exercise-header">
-            <h2 id="exercise-title">Dual N-Back Focus</h2>
-            <nav class="exercise-tabs" id="exercise-tabs" role="tablist" aria-label="Select exercise"></nav>
-          </div>
-          <p class="exercise-tagline" id="exercise-tagline">
-            Track spatial and audio matches from N steps back to deepen working memory capacity.
-          </p>
-          <ul class="exercise-highlights" id="exercise-highlights" role="list"></ul>
-          <div class="exercise-body" id="exercise-body"></div>
-        </section>
+      <section class="workspace" aria-label="Training workspace">
+        <nav class="workspace-tabs" id="workspace-tabs" role="tablist" aria-label="Choose a section">
+          <button
+            class="workspace-tab"
+            id="workspace-tab-training"
+            type="button"
+            role="tab"
+            aria-selected="true"
+            aria-controls="exercise-card"
+            data-target="exercise-card"
+            data-i18n="workspace.tabs.training"
+          >
+            Training drills
+          </button>
+          <button
+            class="workspace-tab"
+            id="workspace-tab-progress"
+            type="button"
+            role="tab"
+            aria-selected="false"
+            tabindex="-1"
+            aria-controls="stats-card"
+            data-target="stats-card"
+            data-i18n="workspace.tabs.progress"
+          >
+            Progress logbook
+          </button>
+        </nav>
 
-        <section class="panel stats-panel" id="stats-card">
-          <h2 data-i18n="stats.title">Progress logbook</h2>
-          <p id="stats-intro" data-i18n="stats.intro">Select a circuit to inspect its personal best, trend, and recent entries.</p>
-          <dl class="stats-grid">
-            <div class="stat">
-              <dt data-i18n="stats.bestLabel">Personal best</dt>
-              <dd id="best-score-value">—</dd>
+        <section class="app-grid workspace-panels" aria-label="Training controls">
+          <section
+            class="panel exercise-panel"
+            id="exercise-card"
+            role="tabpanel"
+            aria-labelledby="workspace-tab-training"
+            data-workspace-panel
+          >
+            <div class="exercise-header">
+              <h2 id="exercise-title">Dual N-Back Focus</h2>
+              <nav class="exercise-tabs" id="exercise-tabs" role="tablist" aria-label="Select exercise"></nav>
             </div>
-            <div class="stat">
-              <dt data-i18n="stats.totalLabel">Total sessions</dt>
-              <dd id="sessions-count-value">0</dd>
+            <p class="exercise-tagline" id="exercise-tagline">
+              Track spatial and audio matches from N steps back to deepen working memory capacity.
+            </p>
+            <ul class="exercise-highlights" id="exercise-highlights" role="list"></ul>
+            <div class="exercise-body" id="exercise-body"></div>
+          </section>
+
+          <section
+            class="panel stats-panel"
+            id="stats-card"
+            role="tabpanel"
+            aria-labelledby="workspace-tab-progress"
+            data-workspace-panel
+            hidden
+          >
+            <h2 data-i18n="stats.title">Progress logbook</h2>
+            <p id="stats-intro" data-i18n="stats.intro">
+              Select a circuit to inspect its personal best, trend, and recent entries.
+            </p>
+            <dl class="stats-grid">
+              <div class="stat">
+                <dt data-i18n="stats.bestLabel">Personal best</dt>
+                <dd id="best-score-value">—</dd>
+              </div>
+              <div class="stat">
+                <dt data-i18n="stats.totalLabel">Total sessions</dt>
+                <dd id="sessions-count-value">0</dd>
+              </div>
+              <div class="stat">
+                <dt data-i18n="stats.latestLabel">Latest result</dt>
+                <dd id="last-score-value">—</dd>
+              </div>
+            </dl>
+            <div class="chart" id="progress-chart"></div>
+            <div class="recent-results">
+              <h3 data-i18n="stats.recentTitle">Recent sessions</h3>
+              <p class="history-empty" id="recent-empty" data-i18n="stats.recentEmpty">No sessions logged yet.</p>
+              <ol class="history-list" id="recent-results-list" aria-live="polite"></ol>
             </div>
-            <div class="stat">
-              <dt data-i18n="stats.latestLabel">Latest result</dt>
-              <dd id="last-score-value">—</dd>
+            <div class="logbook-actions">
+              <button class="button subtle" id="reset-exercise-btn" type="button" data-i18n="stats.clearExercise">Clear this exercise</button>
+              <button class="button subtle" id="reset-all-btn" type="button" data-i18n="stats.resetAll">Reset all progress</button>
             </div>
-          </dl>
-          <div class="chart" id="progress-chart"></div>
-          <div class="recent-results">
-            <h3 data-i18n="stats.recentTitle">Recent sessions</h3>
-            <p class="history-empty" id="recent-empty" data-i18n="stats.recentEmpty">No sessions logged yet.</p>
-            <ol class="history-list" id="recent-results-list" aria-live="polite"></ol>
-          </div>
-          <div class="logbook-actions">
-            <button class="button subtle" id="reset-exercise-btn" type="button" data-i18n="stats.clearExercise">Clear this exercise</button>
-            <button class="button subtle" id="reset-all-btn" type="button" data-i18n="stats.resetAll">Reset all progress</button>
-          </div>
-          <p class="storage-footnote" data-i18n="stats.footnote">
-            These records live only in local storage so you can track growth without creating an account.
-          </p>
+            <p class="storage-footnote" data-i18n="stats.footnote">
+              These records live only in local storage so you can track growth without creating an account.
+            </p>
+          </section>
         </section>
       </section>
     </main>

--- a/styles.css
+++ b/styles.css
@@ -290,6 +290,7 @@ select {
   list-style: none;
   display: grid;
   gap: 0.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .hero-highlight {
@@ -381,11 +382,62 @@ select {
   font-weight: 600;
 }
 
+.workspace {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.workspace-tabs {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem;
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.55);
+  border: 1px solid var(--border-glass);
+  box-shadow: var(--shadow-soft);
+}
+
+.workspace-tab {
+  border: none;
+  border-radius: var(--radius-md);
+  padding: 0.6rem 1.35rem;
+  background: transparent;
+  color: var(--text-body);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.workspace-tab:hover {
+  transform: translateY(-1px);
+  color: var(--text-strong);
+}
+
+.workspace-tab[aria-selected='true'] {
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.9), rgba(14, 165, 233, 0.85));
+  color: #fff;
+  box-shadow: 0 16px 36px rgba(79, 70, 229, 0.3);
+}
+
+.workspace-tab:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.25);
+}
+
 .app-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1.12fr) minmax(0, 0.88fr);
+  grid-template-columns: minmax(0, 1fr);
   gap: clamp(1.75rem, 5vw, 2.5rem);
-  align-items: start;
+  align-items: stretch;
+}
+
+.panel[hidden] {
+  display: none;
 }
 
 .panel {
@@ -934,6 +986,16 @@ select {
   .status-pill {
     width: 100%;
     justify-content: center;
+  }
+
+  .workspace-tabs {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .workspace-tab {
+    flex: 1 1 160px;
+    text-align: center;
   }
 
   .module-bar {


### PR DESCRIPTION
## Summary
- reorganize the dashboard panels behind a new workspace tab bar so only the active section is visible
- add styling updates to support the compact tabbed layout and reduce hero height on wide screens
- extend the app logic and translations to manage workspace tab state and localization

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d2d0f0fb148320bef71b11461e41f1