### PR TITLE
Add camera-based mood trainer experience

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,5 @@
 # Takenlijst
 
-Er zijn momenteel geen openstaande taken. De site is bewust leeg en statisch gehouden.
+- [x] Mood Trainer prototype met gezichtsherkenning opgezet.
+- [ ] Resultatenlogica koppelen aan toekomstige dagoverzicht-module.
+- [ ] Coach-avatar en aanvullende feedbackschermen uitwerken.

--- a/index.html
+++ b/index.html
@@ -3,13 +3,193 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Lege statische site</title>
+    <title>Mood Trainer – gezichtsherkenning</title>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <main class="page" aria-label="Lege pagina">
-      <h1>Lege statische site</h1>
-      <p>Deze pagina bevat geen dynamische functionaliteit en kan veilig als startpunt worden gebruikt.</p>
+    <main class="trainer" aria-label="Mood Trainer sessie">
+      <section class="screen upper" aria-label="Coachingspaneel">
+        <header class="coach-header">
+          <p class="coach-kicker">Dagelijkse training</p>
+          <h1>Mood Trainer</h1>
+          <p class="coach-intro">
+            Richt je op de camera, adem rustig in en laat de digitale coach je stemming lezen. Deze oefening helpt je bewust te worden van je mimiek en dagelijkse gemoed.
+          </p>
+        </header>
+        <div class="status-panel" role="status" aria-live="polite">
+          <p class="panel-label">Sessiestatus</p>
+          <p id="statusMessage">Druk op <strong>Start sessie</strong> om te beginnen.</p>
+        </div>
+        <div class="mood-panel" aria-live="polite">
+          <p class="panel-label">Waargenomen stemming</p>
+          <p id="moodLabel" class="mood-label">–</p>
+          <p id="confidenceLabel" class="confidence-label"></p>
+        </div>
+        <button id="toggleSession" type="button" class="primary">Start sessie</button>
+      </section>
+      <section class="screen lower" aria-label="Camera en analyse">
+        <div class="video-frame">
+          <video id="videoFeed" autoplay muted playsinline aria-label="Live camerabeeld"></video>
+          <canvas id="overlay" aria-hidden="true"></canvas>
+          <p class="video-hint">Zorg voor voldoende licht en kijk ontspannen naar het scherm.</p>
+        </div>
+      </section>
     </main>
+    <script src="https://cdn.jsdelivr.net/npm/face-api.js@0.22.2/dist/face-api.min.js" integrity="sha384-M5m2nzf7rmv2krt55rIJUjVUiZuq6gpy6ADAmIyEFd+ELl1mXc3Yw9+k82kUNSvg" crossorigin="anonymous"></script>
+    <script>
+      const startButton = document.getElementById('toggleSession');
+      const statusMessage = document.getElementById('statusMessage');
+      const moodLabel = document.getElementById('moodLabel');
+      const confidenceLabel = document.getElementById('confidenceLabel');
+      const video = document.getElementById('videoFeed');
+      const overlay = document.getElementById('overlay');
+      const overlayCtx = overlay.getContext('2d');
+
+      const MODEL_URL = 'https://cdn.jsdelivr.net/npm/face-api.js@0.22.2/weights';
+      const TRANSLATIONS = {
+        neutral: 'Neutraal',
+        happy: 'Vrolijk',
+        sad: 'Verdrietig',
+        angry: 'Boos',
+        fearful: 'Bang',
+        disgusted: 'Afkeer',
+        surprised: 'Verbaasd'
+      };
+
+      let modelsLoaded = false;
+      let detecting = false;
+      let stream = null;
+
+      function setStatus(message) {
+        statusMessage.innerHTML = message;
+      }
+
+      function setMood(name, confidence) {
+        if (!name) {
+          moodLabel.textContent = 'Geen gezicht gedetecteerd';
+          confidenceLabel.textContent = '';
+          return;
+        }
+        const translated = TRANSLATIONS[name] || name;
+        moodLabel.textContent = translated;
+        confidenceLabel.textContent = `Vertrouwen: ${Math.round(confidence * 100)}%`;
+      }
+
+      async function ensureModels() {
+        if (modelsLoaded) {
+          return;
+        }
+        setStatus('Modellen laden…');
+        await Promise.all([
+          faceapi.nets.tinyFaceDetector.loadFromUri(MODEL_URL),
+          faceapi.nets.faceExpressionNet.loadFromUri(MODEL_URL)
+        ]);
+        modelsLoaded = true;
+      }
+
+      function resizeOverlay() {
+        const { videoWidth, videoHeight } = video;
+        if (videoWidth === 0 || videoHeight === 0) {
+          return;
+        }
+        overlay.width = videoWidth;
+        overlay.height = videoHeight;
+        overlay.style.width = `${videoWidth}px`;
+        overlay.style.height = `${videoHeight}px`;
+      }
+
+      async function analyseFrame() {
+        if (!detecting) {
+          return;
+        }
+
+        const options = new faceapi.TinyFaceDetectorOptions({ inputSize: 224, scoreThreshold: 0.5 });
+        const detections = await faceapi
+          .detectAllFaces(video, options)
+          .withFaceExpressions();
+
+        overlayCtx.clearRect(0, 0, overlay.width, overlay.height);
+
+        if (!detecting) {
+          return;
+        }
+
+        if (detections.length === 0) {
+          setMood(null);
+        } else {
+          const dims = faceapi.matchDimensions(overlay, video, true);
+          const resized = faceapi.resizeResults(detections, dims);
+          resized.forEach((det) => {
+            const { x, y, width, height } = det.detection.box;
+            overlayCtx.strokeStyle = 'rgba(62, 102, 148, 0.9)';
+            overlayCtx.lineWidth = 3;
+            overlayCtx.strokeRect(x, y, width, height);
+          });
+
+          const first = detections[0];
+          const expressions = first.expressions;
+          const [bestExpression, confidence] = Object.entries(expressions).reduce(
+            (acc, entry) => (entry[1] > acc[1] ? entry : acc),
+            ['neutral', 0]
+          );
+          setMood(bestExpression, confidence);
+        }
+
+        requestAnimationFrame(analyseFrame);
+      }
+
+      function stopSession(message) {
+        detecting = false;
+        startButton.disabled = false;
+        startButton.textContent = 'Start sessie';
+        window.removeEventListener('resize', resizeOverlay);
+        if (stream) {
+          stream.getTracks().forEach((track) => track.stop());
+          stream = null;
+        }
+        if (video.srcObject) {
+          video.srcObject = null;
+        }
+        overlayCtx.clearRect(0, 0, overlay.width, overlay.height);
+        setMood(null);
+        if (message) {
+          setStatus(message);
+        } else {
+          setStatus('Sessie gestopt. Druk op <strong>Start sessie</strong> voor een nieuwe poging.');
+        }
+      }
+
+      async function startSession() {
+        try {
+          startButton.disabled = true;
+          setStatus('Voorbereiden…');
+          await ensureModels();
+          setStatus('Camera starten…');
+          stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'user' } });
+          video.srcObject = stream;
+          await video.play();
+          resizeOverlay();
+          window.addEventListener('resize', resizeOverlay);
+          detecting = true;
+          startButton.textContent = 'Stop sessie';
+          startButton.disabled = false;
+          setStatus('Analyseren. Ontspan je gezicht en kijk naar de camera.');
+          requestAnimationFrame(analyseFrame);
+        } catch (error) {
+          console.error(error);
+          stopSession('Het lukt niet om de camera of modellen te laden. Controleer je rechten en probeer opnieuw.');
+        }
+      }
+
+      startButton.addEventListener('click', () => {
+        if (detecting) {
+          stopSession();
+        } else {
+          startSession();
+        }
+      });
+
+      video.addEventListener('loadedmetadata', resizeOverlay);
+    </script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -6,31 +6,179 @@
   box-sizing: border-box;
 }
 
+:root {
+  --trainer-bg: linear-gradient(180deg, #f8f4e9 0%, #e3dcc5 100%);
+  --screen-border: #d0c7b1;
+  --screen-shadow: rgba(63, 63, 63, 0.15);
+  --primary-blue: #3e6694;
+  --accent: #f2a057;
+  --text-color: #2f343f;
+  --soft-text: #5b6270;
+  --panel-bg: rgba(255, 255, 255, 0.72);
+}
+
 body {
   margin: 0;
   min-height: 100vh;
-  font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
-  background: #f5f5f5;
-  color: #333;
+  font-family: "Segoe UI", "Helvetica Neue", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background: var(--trainer-bg);
+  color: var(--text-color);
   display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5rem 1rem;
+}
+
+main.trainer {
+  display: grid;
+  gap: 1.5rem;
+  width: min(960px, 100%);
+  grid-template-columns: 1fr;
+}
+
+.screen {
+  background: rgba(255, 255, 255, 0.92);
+  border: 4px solid var(--screen-border);
+  border-radius: 28px;
+  box-shadow: 0 20px 45px var(--screen-shadow);
+  padding: clamp(1.25rem, 4vw, 2.25rem);
+}
+
+.screen.upper {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.screen.lower {
+  display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
 }
 
-.page {
-  max-width: 640px;
-  width: 100%;
-  padding: 3rem 1.5rem;
+.coach-header {
   text-align: center;
 }
 
-h1 {
-  margin-bottom: 1rem;
-  font-size: clamp(2rem, 5vw, 2.5rem);
+.coach-kicker {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--accent);
+  margin: 0 0 0.5rem;
 }
 
-p {
+h1 {
   margin: 0;
-  font-size: clamp(1rem, 4vw, 1.125rem);
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  font-weight: 700;
+  color: var(--primary-blue);
+}
+
+.coach-intro {
+  margin: 0.75rem auto 0;
+  max-width: 40ch;
   line-height: 1.6;
+  color: var(--soft-text);
+}
+
+.panel-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 0.3rem;
+}
+
+.status-panel,
+.mood-panel {
+  padding: 1rem 1.25rem;
+  background: var(--panel-bg);
+  border-radius: 18px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+}
+
+.status-panel p,
+.mood-panel p {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.mood-label {
+  font-size: clamp(1.75rem, 5vw, 2.2rem);
+  font-weight: 600;
+  color: var(--primary-blue);
+}
+
+.confidence-label {
+  margin-top: 0.3rem;
+  color: var(--soft-text);
+}
+
+button.primary {
+  justify-self: center;
+  padding: 0.85rem 2.5rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, var(--primary-blue), #27476d);
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 10px 20px rgba(39, 71, 109, 0.2);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+}
+
+button.primary:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 28px rgba(39, 71, 109, 0.28);
+}
+
+button.primary:active:not(:disabled) {
+  transform: translateY(0);
+  filter: brightness(0.95);
+}
+
+button.primary:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.video-frame {
+  position: relative;
+  width: min(640px, 100%);
+  background: #111;
+  border-radius: 22px;
+  overflow: hidden;
+  border: 6px solid rgba(0, 0, 0, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+}
+
+.video-frame video,
+.video-frame canvas {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.video-frame canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.video-hint {
+  margin-top: 0.75rem;
+  text-align: center;
+  color: var(--soft-text);
+  font-size: 0.95rem;
+}
+
+@media (min-width: 960px) {
+  main.trainer {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }


### PR DESCRIPTION
## Summary
- replace the placeholder page with a dual-screen geïnspireerde Mood Trainer
- integrate face-api.js to analyse camera beelden en toon stemming met vertrouwen
- update takenlijst met vervolgstappen rond dagoverzichten en coach-avatar

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68dcc75d4248832093509ccad5e2bbc0