### PR TITLE
Replace hamburger menu with swipeable navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,22 +31,13 @@
             <span class="logo" aria-hidden="true">⌘</span>
             <span class="brand-wordmark">Codex Studio</span>
           </div>
-          <button
-            class="nav-toggle"
-            type="button"
-            aria-expanded="false"
-            aria-controls="primary-navigation"
-          >
-            <span class="sr-only">Toggle navigation</span>
-            <span class="nav-toggle-icon" aria-hidden="true"></span>
-          </button>
-          <nav class="site-nav" aria-label="Primary">
-            <ul id="primary-navigation" class="nav-links">
-              <li><a href="#services">Services</a></li>
-              <li><a href="#highlights">Highlights</a></li>
-              <li><a href="#testimonial">Story</a></li>
-              <li><a href="#contact">Contact</a></li>
-            </ul>
+          <nav class="swipe-nav" aria-label="Primary">
+            <div class="nav-track" id="primary-navigation">
+              <a class="nav-pill" href="#services">Services</a>
+              <a class="nav-pill" href="#highlights">Highlights</a>
+              <a class="nav-pill" href="#testimonial">Story</a>
+              <a class="nav-pill" href="#contact">Contact</a>
+            </div>
           </nav>
         </div>
         <div class="intro">
@@ -176,65 +167,146 @@
       const now = new Date();
       yearEl.textContent = now.getFullYear();
 
-      const navToggle = document.querySelector('.nav-toggle');
-      const nav = document.querySelector('.site-nav');
+      const navTrack = document.querySelector('.nav-track');
+      const navLinks = Array.from(document.querySelectorAll('.nav-pill'));
+      const observedSections = Array.from(
+        document.querySelectorAll('main .section')
+      );
 
-      if (navToggle && nav) {
-        const navLinks = nav.querySelectorAll('a');
-        const mq = window.matchMedia('(min-width: 720px)');
-
-        const syncNavAria = () => {
-          if (navToggle.offsetParent !== null) {
-            const expanded = navToggle.getAttribute('aria-expanded') === 'true';
-            nav.setAttribute('aria-hidden', expanded ? 'false' : 'true');
-          } else {
-            nav.setAttribute('aria-hidden', 'false');
-          }
-        };
-
-        const closeNav = () => {
-          nav.classList.remove('is-open');
-          document.body.classList.remove('nav-open');
-          navToggle.setAttribute('aria-expanded', 'false');
-          syncNavAria();
-        };
-
-        const handleMediaChange = (event) => {
-          if (event.matches) {
-            closeNav();
-          }
-          syncNavAria();
-        };
-
-        navToggle.addEventListener('click', () => {
-          const expanded = navToggle.getAttribute('aria-expanded') === 'true';
-          navToggle.setAttribute('aria-expanded', String(!expanded));
-          nav.classList.toggle('is-open');
-          document.body.classList.toggle('nav-open');
-          syncNavAria();
-        });
+      if (navTrack && navLinks.length > 0) {
+        navTrack.setAttribute('role', 'list');
+        navTrack.setAttribute('tabindex', '0');
+        navTrack.setAttribute('aria-orientation', 'horizontal');
 
         navLinks.forEach((link) => {
-          link.addEventListener('click', () => {
-            if (navToggle.offsetParent !== null) {
-              closeNav();
+          link.setAttribute('role', 'listitem');
+          link.addEventListener('click', (event) => {
+            event.preventDefault();
+            const targetId = link.getAttribute('href');
+            const target = document.querySelector(targetId);
+
+            if (target) {
+              target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+              setActiveLink(targetId.substring(1));
             }
           });
         });
 
-        document.addEventListener('keydown', (event) => {
-          if (event.key === 'Escape' && document.body.classList.contains('nav-open')) {
-            closeNav();
+        const pointerState = {
+          isPointerDown: false,
+          startX: 0,
+          scrollLeft: 0,
+          pointerId: null,
+        };
+
+        const releasePointer = () => {
+          if (pointerState.pointerId !== null) {
+            navTrack.releasePointerCapture(pointerState.pointerId);
           }
+          pointerState.isPointerDown = false;
+          pointerState.pointerId = null;
+        };
+
+        navTrack.addEventListener('pointerdown', (event) => {
+          pointerState.isPointerDown = true;
+          pointerState.startX = event.clientX;
+          pointerState.scrollLeft = navTrack.scrollLeft;
+          pointerState.pointerId = event.pointerId;
+          navTrack.classList.add('is-grabbing');
+          navTrack.setPointerCapture(event.pointerId);
         });
 
-        if (typeof mq.addEventListener === 'function') {
-          mq.addEventListener('change', handleMediaChange);
-        } else if (typeof mq.addListener === 'function') {
-          mq.addListener(handleMediaChange);
-        }
+        navTrack.addEventListener('pointermove', (event) => {
+          if (!pointerState.isPointerDown) {
+            return;
+          }
 
-        syncNavAria();
+          const deltaX = event.clientX - pointerState.startX;
+          navTrack.scrollLeft = pointerState.scrollLeft - deltaX;
+        });
+
+        navTrack.addEventListener('pointerup', () => {
+          navTrack.classList.remove('is-grabbing');
+          releasePointer();
+        });
+
+        navTrack.addEventListener('pointercancel', () => {
+          navTrack.classList.remove('is-grabbing');
+          releasePointer();
+        });
+
+        navTrack.addEventListener('keydown', (event) => {
+          const isHorizontal = event.key === 'ArrowRight' || event.key === 'ArrowLeft';
+
+          if (!isHorizontal) {
+            return;
+          }
+
+          const direction = event.key === 'ArrowRight' ? 1 : -1;
+          const focusable = navLinks;
+          const currentIndex = focusable.indexOf(document.activeElement);
+          const nextIndex = Math.min(
+            focusable.length - 1,
+            Math.max(0, currentIndex + direction)
+          );
+
+          if (focusable[nextIndex]) {
+            focusable[nextIndex].focus();
+            const targetId = focusable[nextIndex].getAttribute('href').substring(1);
+            setActiveLink(targetId);
+          }
+
+          navTrack.scrollBy({
+            left: direction * navTrack.clientWidth * 0.6,
+            behavior: 'smooth',
+          });
+        });
+
+        const setActiveLink = (sectionId) => {
+          navLinks.forEach((link) => {
+            const isActive = link.getAttribute('href') === `#${sectionId}`;
+            link.classList.toggle('is-active', isActive);
+
+            if (isActive) {
+              link.setAttribute('aria-current', 'true');
+
+              requestAnimationFrame(() => {
+                const linkRect = link.getBoundingClientRect();
+                const trackRect = navTrack.getBoundingClientRect();
+                const offset =
+                  linkRect.left -
+                  trackRect.left -
+                  (trackRect.width - linkRect.width) / 2;
+                navTrack.scrollBy({ left: offset, behavior: 'smooth' });
+              });
+            } else {
+              link.removeAttribute('aria-current');
+            }
+          });
+        };
+
+        const observer = new IntersectionObserver(
+          (entries) => {
+            const visible = entries
+              .filter((entry) => entry.isIntersecting)
+              .sort((a, b) => b.intersectionRatio - a.intersectionRatio);
+
+            if (visible[0]) {
+              setActiveLink(visible[0].target.id);
+            }
+          },
+          {
+            root: null,
+            threshold: [0.3, 0.6, 0.9],
+            rootMargin: '-40% 0px -50% 0px',
+          }
+        );
+
+        observedSections.forEach((section) => observer.observe(section));
+
+        if (observedSections[0]) {
+          setActiveLink(observedSections[0].id);
+        }
       }
     </script>
   </body>

--- a/styles.css
+++ b/styles.css
@@ -132,96 +132,75 @@ body {
   z-index: 1;
 }
 
-.nav-toggle {
+.swipe-nav {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  max-width: min(28rem, 100%);
+}
+
+.nav-track {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  background: rgba(90, 93, 240, 0.08);
+  border-radius: 999px;
+  padding: 0.4rem 0.5rem;
+  box-shadow: inset 0 0 0 1px rgba(90, 93, 240, 0.15), var(--shadow-soft);
+  overflow-x: auto;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+  scroll-snap-type: x proximity;
+  position: relative;
+  cursor: grab;
+}
+
+.nav-track::-webkit-scrollbar {
+  display: none;
+}
+
+.nav-track:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px rgba(90, 93, 240, 0.4), var(--shadow-soft);
+}
+
+.nav-track.is-grabbing {
+  cursor: grabbing;
+}
+
+.nav-pill {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.75rem;
-  height: 2.75rem;
+  padding: 0.55rem 1.1rem;
   border-radius: 999px;
-  border: none;
-  background: rgba(90, 93, 240, 0.12);
-  color: inherit;
-  cursor: pointer;
-  box-shadow: inset 0 0 0 1px rgba(90, 93, 240, 0.18);
-  transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
-}
-
-.nav-toggle:hover,
-.nav-toggle:focus-visible {
-  transform: translateY(-1px);
-  background: rgba(90, 93, 240, 0.18);
-  box-shadow: inset 0 0 0 1px rgba(90, 93, 240, 0.24);
-}
-
-.nav-toggle-icon,
-.nav-toggle-icon::before,
-.nav-toggle-icon::after {
-  display: block;
-  width: 1.25rem;
-  height: 2px;
-  border-radius: 1px;
-  background: var(--text-primary);
-  transition: transform 0.2s ease, opacity 0.2s ease;
-}
-
-.nav-toggle-icon {
-  position: relative;
-}
-
-.nav-toggle-icon::before,
-.nav-toggle-icon::after {
-  content: "";
-  position: absolute;
-  left: 0;
-}
-
-.nav-toggle-icon::before {
-  transform: translateY(-6px);
-}
-
-.nav-toggle-icon::after {
-  transform: translateY(6px);
-}
-
-.site-nav {
-  position: relative;
-  z-index: 10;
-}
-
-.nav-links {
-  list-style: none;
-  display: flex;
-  gap: 1.25rem;
-  margin: 0;
-  padding: 0;
-}
-
-.nav-links a {
   font-weight: 600;
-  font-size: 0.95rem;
-  color: var(--text-primary);
+  font-size: 0.9rem;
+  letter-spacing: 0.02em;
   text-decoration: none;
-  padding: 0.4rem 0;
-  position: relative;
+  color: var(--text-secondary);
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(90, 93, 240, 0.18);
+  scroll-snap-align: center;
+  transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+  white-space: nowrap;
 }
 
-.nav-links a::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  width: 100%;
-  height: 2px;
-  background: var(--accent);
-  transform: scaleX(0);
-  transform-origin: left;
-  transition: transform 0.2s ease;
+.nav-pill:hover,
+.nav-pill:focus-visible {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 12px 24px rgba(90, 93, 240, 0.14);
+  color: var(--text-primary);
+  border-color: rgba(90, 93, 240, 0.32);
 }
 
-.nav-links a:focus-visible::after,
-.nav-links a:hover::after {
-  transform: scaleX(1);
+.nav-pill.is-active {
+  background: linear-gradient(135deg, var(--accent), #7d5ff0);
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 16px 36px rgba(90, 93, 240, 0.32);
 }
 
 .eyebrow,
@@ -445,70 +424,29 @@ main {
   padding-bottom: 1rem;
 }
 
-body.nav-open {
-  overflow: hidden;
-}
-
-body.nav-open::before {
-  content: "";
-  position: fixed;
-  inset: 0;
-  background: rgba(27, 31, 47, 0.35);
-  backdrop-filter: blur(4px);
-  z-index: 5;
-}
-
-.nav-toggle[aria-expanded="true"] .nav-toggle-icon {
-  background: transparent;
-}
-
-.nav-toggle[aria-expanded="true"] .nav-toggle-icon::before {
-  transform: rotate(45deg);
-}
-
-.nav-toggle[aria-expanded="true"] .nav-toggle-icon::after {
-  transform: rotate(-45deg);
-}
-
 @media (max-width: 720px) {
   .brand-wordmark {
     font-size: 0.9rem;
   }
 
-  .site-nav {
-    position: absolute;
-    top: clamp(2.5rem, 6vw, 4rem);
-    right: clamp(1.75rem, 5vw, 3.5rem);
-    width: min(18rem, 70vw);
-    padding: 1.75rem;
-    background: var(--surface);
-    border-radius: var(--radius-medium);
-    box-shadow: var(--shadow-soft);
-    opacity: 0;
-    pointer-events: none;
-    transform: translateY(-1rem);
-    transition: opacity 0.25s ease, transform 0.25s ease;
-  }
-
-  .site-nav.is-open {
-    opacity: 1;
-    pointer-events: auto;
-    transform: translateY(0);
-  }
-
-  .nav-links {
+  .header-top {
     flex-direction: column;
-    gap: 1rem;
-  }
-}
-
-@media (min-width: 721px) {
-  .nav-toggle {
-    display: none;
+    align-items: stretch;
+    gap: 1.25rem;
   }
 
-  .site-nav {
-    margin-left: auto;
+  .swipe-nav {
+    width: 100%;
+    margin-left: 0;
+  }
+
+  .nav-track {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .nav-pill {
+    flex: 0 0 auto;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the failing hamburger toggle with a swipeable primary navigation rail that keeps the DS-inspired styling
- add interaction logic for pointer drag, keyboard support, and section tracking so the active pill stays in sync while scrolling
- refresh navigation styles for the new pill design and responsive layout adjustments

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e42b8eba2c8320ae1da01abe0bdb25