### PR TITLE
Fix lint config and papaparse typing issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,12 @@
   "devDependencies": {
     "@types/node": "^20.12.12",
     "@types/react": "^18.3.3",
+    "@types/papaparse": "^5.2.7",
     "@types/react-dom": "^18.3.0",
     "autoprefixer": "^10.4.19",
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.4",
+    "eslint-config-prettier": "^9.1.0",
     "postcss": "^8.4.38",
     "prettier": "^3.3.3",
     "tailwindcss": "^3.4.4",


### PR DESCRIPTION
## Summary
- add the missing eslint-config-prettier package so the shared lint config resolves
- include @types/papaparse to satisfy TypeScript when importing Papa Parse

## Testing
- npm install *(fails: npm registry responded with 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e61d60be988320acb4c8bdb4b6efde