### PR TITLE
Fix PapaParse type errors and tolerate missing prettier config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,16 @@
-module.exports = {
+const config = {
   root: true,
-  extends: ['next/core-web-vitals', 'prettier'],
+  extends: ['next/core-web-vitals'],
   rules: {
     'react-hooks/exhaustive-deps': 'warn'
   }
 };
+
+try {
+  require.resolve('eslint-config-prettier');
+  config.extends.push('prettier');
+} catch (error) {
+  // eslint-config-prettier is optional; ignore if it's not installed.
+}
+
+module.exports = config;

--- a/lib/csv.ts
+++ b/lib/csv.ts
@@ -129,11 +129,11 @@ export const parseCsvFile = async (
           })();
 
           resolve({ type, rows: payload });
-        } catch (error) {
+        } catch (error: unknown) {
           reject(error);
         }
       },
-      error: (error) => reject(error)
+      error: (error: unknown) => reject(error)
     });
   });
 };

--- a/types/papaparse.d.ts
+++ b/types/papaparse.d.ts
@@ -1,0 +1,63 @@
+declare module 'papaparse' {
+  export type ParseError = {
+    type: string;
+    code: string;
+    message: string;
+    row: number;
+  };
+
+  export type ParseMeta = {
+    delimiter: string;
+    linebreak: string;
+    aborted: boolean;
+    truncated: boolean;
+    cursor: number;
+    fields?: string[];
+  };
+
+  export type ParseResult<T> = {
+    data: T[];
+    errors: ParseError[];
+    meta: ParseMeta;
+  };
+
+  export type TransformHeaderFunction = (header: string) => string;
+
+  export type CompleteFunction<T> = (results: ParseResult<T>) => void;
+
+  export interface ParseConfig<T> {
+    delimiter?: string;
+    newline?: string;
+    quoteChar?: string;
+    escapeChar?: string;
+    header?: boolean;
+    dynamicTyping?: boolean | Record<string, boolean>;
+    preview?: number;
+    encoding?: string;
+    worker?: boolean;
+    comments?: boolean | string;
+    download?: boolean;
+    downloadRequestHeaders?: Record<string, string>;
+    skipEmptyLines?: boolean | 'greedy';
+    fastMode?: boolean;
+    transform?: (value: string, field?: string | number) => string;
+    transformHeader?: TransformHeaderFunction;
+    step?: CompleteFunction<T>;
+    complete?: CompleteFunction<T>;
+    error?: (error: ParseError) => void;
+  }
+
+  export type Parse = <T>(input: string | File, config?: ParseConfig<T>) => ParseResult<T>;
+
+  export type Unparse = (data: unknown, config?: Record<string, unknown>) => string;
+
+  export const parse: Parse;
+  export const unparse: Unparse;
+
+  const Papa: {
+    parse: Parse;
+    unparse: Unparse;
+  };
+
+  export default Papa;
+}


### PR DESCRIPTION
## Summary
- annotate PapaParse error handlers so TypeScript no longer infers `any`
- bundle minimal local type declarations for PapaParse usage
- gracefully handle missing `eslint-config-prettier` so linting still runs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e61f4de7b08320889d90a336e5534e