### PR TITLE
Add generated favicon to avoid 404 errors

### DIFF
--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -1,0 +1,34 @@
+import { ImageResponse } from 'next/og';
+
+export const size = {
+  width: 64,
+  height: 64
+};
+
+export const contentType = 'image/png';
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'linear-gradient(135deg, #0f172a, #1e293b)',
+          color: '#38bdf8',
+          fontSize: 36,
+          fontWeight: 700,
+          letterSpacing: -1
+        }}
+      >
+        LG
+      </div>
+    ),
+    {
+      ...size
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- add a generated favicon at `app/icon.tsx` so Next.js serves `/favicon.ico`
- style the icon with a gradient background and "LG" initials to match the brand palette

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e66128b3f88320b0c8da72980a661e