### PR TITLE
Add middleware fallback for LifeGraph Lite home

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,52 +1,5 @@
-'use client';
+import HomePage from '@/components/HomePage';
 
-import { ActionSection } from '@/components/ActionSection';
-import { DetailsPanel } from '@/components/DetailsPanel';
-import { FiltersSection } from '@/components/FiltersSection';
-import { GraphView } from '@/components/GraphView';
-import { InsightsPanel } from '@/components/InsightsPanel';
-import { UploadSection } from '@/components/UploadSection';
-import { useLifegraphStore } from '@/store/useLifegraphStore';
-
-export default function HomePage() {
-  const data = useLifegraphStore((state) => state.data);
-  const filters = useLifegraphStore((state) => state.filters);
-  const refreshToken = useLifegraphStore((state) => state.refreshToken);
-  const selection = useLifegraphStore((state) => state.selection);
-  const setSelection = useLifegraphStore((state) => state.setSelection);
-
-  return (
-    <main className="px-4 py-6 md:px-8">
-      <div className="mx-auto flex max-w-7xl flex-col gap-6">
-        <header className="space-y-2">
-          <h1 className="text-3xl font-bold text-slate-50">LifeGraph Lite</h1>
-          <p className="max-w-2xl text-sm text-slate-400">
-            Een lichte cockpit voor relaties tussen mensen, deals, meetings en workouts. Upload CSV-bestanden,
-            visualiseer het netwerk en krijg snelle inzichten over de afgelopen weken.
-          </p>
-        </header>
-        <section className="grid grid-cols-1 gap-6 lg:grid-cols-[320px,1fr,320px]">
-          <aside className="order-1 space-y-4 lg:order-none">
-            <UploadSection />
-            <FiltersSection />
-            <ActionSection />
-          </aside>
-          <div className="order-3 flex flex-col gap-4 lg:order-none">
-            <div className="min-h-[400px] rounded-lg border border-slate-800 bg-surface p-2">
-              <GraphView
-                data={data}
-                filters={filters}
-                refreshToken={refreshToken}
-                onSelect={setSelection}
-              />
-            </div>
-            <InsightsPanel data={data} filters={filters} />
-          </div>
-          <div className="order-2 lg:order-none">
-            <DetailsPanel selection={selection} />
-          </div>
-        </section>
-      </div>
-    </main>
-  );
+export default function Page() {
+  return <HomePage />;
 }

--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { ActionSection } from '@/components/ActionSection';
+import { DetailsPanel } from '@/components/DetailsPanel';
+import { FiltersSection } from '@/components/FiltersSection';
+import { GraphView } from '@/components/GraphView';
+import { InsightsPanel } from '@/components/InsightsPanel';
+import { UploadSection } from '@/components/UploadSection';
+import { useLifegraphStore } from '@/store/useLifegraphStore';
+
+export const HomePage = () => {
+  const data = useLifegraphStore((state) => state.data);
+  const filters = useLifegraphStore((state) => state.filters);
+  const refreshToken = useLifegraphStore((state) => state.refreshToken);
+  const selection = useLifegraphStore((state) => state.selection);
+  const setSelection = useLifegraphStore((state) => state.setSelection);
+
+  return (
+    <main className="px-4 py-6 md:px-8">
+      <div className="mx-auto flex max-w-7xl flex-col gap-6">
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold text-slate-50">LifeGraph Lite</h1>
+          <p className="max-w-2xl text-sm text-slate-400">
+            Een lichte cockpit voor relaties tussen mensen, deals, meetings en workouts. Upload CSV-bestanden,
+            visualiseer het netwerk en krijg snelle inzichten over de afgelopen weken.
+          </p>
+        </header>
+        <section className="grid grid-cols-1 gap-6 lg:grid-cols-[320px,1fr,320px]">
+          <aside className="order-1 space-y-4 lg:order-none">
+            <UploadSection />
+            <FiltersSection />
+            <ActionSection />
+          </aside>
+          <div className="order-3 flex flex-col gap-4 lg:order-none">
+            <div className="min-h-[400px] rounded-lg border border-slate-800 bg-surface p-2">
+              <GraphView data={data} filters={filters} refreshToken={refreshToken} onSelect={setSelection} />
+            </div>
+            <InsightsPanel data={data} filters={filters} />
+          </div>
+          <div className="order-2 lg:order-none">
+            <DetailsPanel selection={selection} />
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+};
+
+export default HomePage;

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (pathname === '/' || pathname.startsWith('/_next') || pathname.startsWith('/icon') || pathname === '/favicon.ico') {
+    return NextResponse.next();
+  }
+
+  const url = request.nextUrl.clone();
+  url.pathname = '/';
+  return NextResponse.rewrite(url);
+}
+
+export const config = {
+  matcher: ['/((?!_next|.*\\..*).*)']
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,16 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]
-    }
+    },
+    "plugins": [{ "name": "next" }]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.cjs",
+    "**/*.mjs",
+    ".next/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- refactor the client-side home UI into a reusable `HomePage` component consumed by the app router entry point
- add a middleware rewrite that routes unknown paths back to `/` so the deployed site no longer returns 404s
- update the TypeScript configuration metadata emitted by the Next.js toolchain

## Testing
- npm run lint
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68e6648c71b48320a72fbc24517db7a6