### PR TITLE
Add middleware rewrite for unknown routes

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,29 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+const PUBLIC_FILE = /\.(.*)$/;
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (
+    pathname === '/' ||
+    pathname.startsWith('/_next') ||
+    pathname.startsWith('/api') ||
+    pathname.startsWith('/_vercel')
+  ) {
+    return NextResponse.next();
+  }
+
+  if (PUBLIC_FILE.test(pathname)) {
+    return NextResponse.next();
+  }
+
+  const url = request.nextUrl.clone();
+  url.pathname = '/';
+  return NextResponse.rewrite(url);
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)']
+};


### PR DESCRIPTION
## Summary
- add an application middleware that rewrites unknown routes back to the homepage
- ensure static assets, Next.js internals, API routes, and Vercel endpoints bypass the rewrite logic

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e7dcf1d2f48320b5001ed4d93641b0