### PR TITLE
Fix edge runtime error for the icon route

### DIFF
--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -1,3 +1,5 @@
+export const runtime = 'edge';
+
 import { ImageResponse } from 'next/og';
 
 export const size = {


### PR DESCRIPTION
## Summary
- mark the generated app icon route to use the edge runtime so it no longer relies on Node-only globals

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e7df83d9ec8320b81a0b6e4c7ec07f